### PR TITLE
fix 401 when getting auth codes

### DIFF
--- a/pkg/client/trakt.go
+++ b/pkg/client/trakt.go
@@ -250,7 +250,11 @@ func (tc *TraktClient) GetAuthCodes() (*entities.TraktAuthCodesResponse, error) 
 		BasePath: traktPathBaseAPI,
 		Endpoint: traktPathAuthCodes,
 		Body:     bytes.NewReader(body),
-		Headers:  tc.defaultApiHeaders(),
+		Headers: map[string]string{
+			traktHeaderKeyApiVersion:  "2",
+			traktHeaderKeyContentType: "application/json",
+			traktHeaderKeyApiKey:      *tc.config.ClientID,
+		},
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The reason for the 401 in the POST https://api.trakt.tv/oauth/device/code is the Authorization header. Simply removing the header resolves the issue. Fixes #28 