### PR TITLE
feat: provide auth method options

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -7,13 +7,16 @@ on:
     - cron: "0 */12 * * *"
   workflow_dispatch:
 env:
+  ITS_IMDB_AUTH: ${{ secrets.IMDB_AUTH }}
   ITS_IMDB_EMAIL: ${{ secrets.IMDB_EMAIL }}
-  ITS_IMDB_HEADLESS: true
-  ITS_IMDB_LISTS: ${{ secrets.IMDB_LISTS }}
   ITS_IMDB_PASSWORD: ${{ secrets.IMDB_PASSWORD }}
+  ITS_IMDB_COOKIEATMAIN: ${{ secrets.IMDB_COOKIEATMAIN }}
+  ITS_IMDB_COOKIEUBIDMAIN: ${{ secrets.IMDB_COOKIEUBIDMAIN }}
+  ITS_IMDB_LISTS: ${{ secrets.IMDB_LISTS }}
   ITS_IMDB_TRACE: ${{ secrets.IMDB_TRACE }}
+  ITS_IMDB_HEADLESS: true
   ITS_SYNC_MODE: ${{ secrets.SYNC_MODE }}
-  ITS_SYNC_SKIPHISTORY: ${{ secrets.SYNC_SKIPHISTORY }}
+  ITS_SYNC_HISTORY: ${{ secrets.SYNC_HISTORY }}
   ITS_SYNC_TIMEOUT: ${{ secrets.SYNC_TIMEOUT }}
   ITS_TRAKT_CLIENTID: ${{ secrets.TRAKT_CLIENTID }}
   ITS_TRAKT_CLIENTSECRET: ${{ secrets.TRAKT_CLIENTSECRET }}

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -27,7 +27,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 			return conf.Validate()
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			timeoutCtx, cancel := context.WithTimeout(ctx, conf.Sync.Timeout)
+			timeoutCtx, cancel := context.WithTimeout(ctx, *conf.Sync.Timeout)
 			defer cancel()
 			s, err := syncer.NewSyncer(timeoutCtx, conf)
 			if err != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -1,10 +1,25 @@
 IMDB:
+    # Authentication method to be used for IMDb
+    # The value must be one of the following:
+    #   credentials - IMDB_EMAIL & IMDB_PASSWORD
+    #   cookies     - IMDB_COOKIEATMAIN & IMDB_COOKIEUBIDMAIN
+    AUTH: credentials
     # IMDb account email address
     # You need to replace this value with your own, the default value is for illustrative purposes only
     EMAIL: user@domain.com
     # IMDb account password
     # You need to replace this value with your own, the default value is for illustrative purposes only
-    PASSWORD: password
+    PASSWORD: password123
+    # The cookies can be used as a fallback if captcha is preventing the authentication flow
+    # Log into your IMDb account from a web browser, inspect the cookies and retrieve the value of cookie:
+    # name: at-main | domain: .imdb.com
+    # You need to replace this value with your own, the default value is for illustrative purposes only
+    COOKIEATMAIN: zAta|RHiA67JIrBDPaswIym3GyrTlEuQH-u9yrKP3BUNCHgVyE4oNtUzBYVKlhjjzBiM_Z-GSVnH9rKW3Hf7LdbejovoF6SI4ZmgJcTIUXoA4NVcH1Qahwm0KYCyz95o1gsgby-uQwdU6CoS6MFTnjMkLe1puNiv4uFkvo8mOQulJJeutzYedxiUd0ns9w1X_WeVXPTZWjwisPZMw3EOR6-q9xR4kCEWRW7CmWxU1AEDQbT8ns_AJJD34w1nIQUkuLgBQrvJI_pY
+    # The cookies can be used as a fallback if captcha is preventing the authentication flow
+    # Log into your IMDb account from a web browser, inspect the cookies and retrieve the value of cookie:
+    # name: ubid-main | domain: .imdb.com
+    # You need to replace this value with your own, the default value is for illustrative purposes only
+    COOKIEUBIDMAIN: 301-0710501-5367639
     # Array of IMDb lists that you would like synced to Trakt
     # If this array is empty, all IMDb lists will be synced to Trakt
     # Keep in mind the maximum number of lists you can have in Trakt: https://twitter.com/trakt/status/1536751362943332352
@@ -13,11 +28,11 @@ IMDB:
         - ls000000000
         - ls111111111
     # Print tracing logs related to browser activities
-    # Only use for debugging purposes as trace logging is quite verbose
+    # Can be useful for debugging purposes
     TRACE: false
     # Whether to run the browser in headless mode or not
     # For local debugging you can set this value to false
-    # If running via GitHub Actions or other CI the value should always be true
+    # If running via GitHub Actions or other CI the value will always be true
     HEADLESS: true
 SYNC:
     # Sync mode to be used when running the application
@@ -26,11 +41,11 @@ SYNC:
     #   add-only - sync only newly added IMDb items to Trakt
     #   dry-run  - identify what IMDb items would be added, deleted or updated on Trakt
     MODE: full
-    # Whether to skip history sync or not. If set to true, history sync will be skipped
+    # Whether to sync history or not. If set to true, history sync will be synced
     # IMDb doesn't offer functionality similar to Trakt history, hence why there can't be a direct mapping between them
     # The syncer will assume you have watched an item if you've submitted a rating for it
     # If the above is satisfied and your history for this item is empty, then a new history entry will be added...
-    SKIPHISTORY: true
+    HISTORY: false
     # Maximum duration time to run the syncer
     # Users with large IMDb/Trakt libraries might have to increase the timeout value accordingly
     # Valid time units are: ns, us (or µs), ms, s, m, h
@@ -47,4 +62,4 @@ TRAKT:
     EMAIL: user@domain.com
     # Trakt account password
     # You need to replace this value with your own, the default value is for illustrative purposes only
-    PASSWORD: password
+    PASSWORD: password123

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
@@ -16,11 +15,14 @@ import (
 )
 
 type IMDb struct {
-	Email    *string   `koanf:"EMAIL"`
-	Password *string   `koanf:"PASSWORD"`
-	Lists    *[]string `koanf:"LISTS"`
-	Trace    bool      `koanf:"TRACE"`
-	Headless bool      `koanf:"HEADLESS"`
+	Auth           *string   `koanf:"AUTH"`
+	Email          *string   `koanf:"EMAIL"`
+	Password       *string   `koanf:"PASSWORD"`
+	CookieAtMain   *string   `koanf:"COOKIEATMAIN"`
+	CookieUbidMain *string   `koanf:"COOKIEUBIDMAIN"`
+	Lists          *[]string `koanf:"LISTS"`
+	Trace          *bool     `koanf:"TRACE"`
+	Headless       *bool     `koanf:"HEADLESS"`
 }
 
 type Trakt struct {
@@ -31,9 +33,9 @@ type Trakt struct {
 }
 
 type Sync struct {
-	Mode        *string       `koanf:"MODE"`
-	SkipHistory *bool         `koanf:"SKIPHISTORY"`
-	Timeout     time.Duration `koanf:"TIMEOUT"`
+	Mode    *string        `koanf:"MODE"`
+	History *bool          `koanf:"HISTORY"`
+	Timeout *time.Duration `koanf:"TIMEOUT"`
 }
 
 type Config struct {
@@ -47,10 +49,12 @@ const (
 	delimiter = "_"
 	prefix    = "ITS" + delimiter
 
-	SyncModeAddOnly    = "add-only"
-	SyncModeDryRun     = "dry-run"
-	SyncModeFull       = "full"
-	SyncTimeoutDefault = time.Minute * 10
+	IMDbAuthMethodCredentials = "credentials"
+	IMDbAuthMethodCookies     = "cookies"
+	SyncModeAddOnly           = "add-only"
+	SyncModeDryRun            = "dry-run"
+	SyncModeFull              = "full"
+	SyncTimeoutDefault        = time.Minute * 10
 )
 
 func New(path string, includeEnv bool) (*Config, error) {
@@ -71,6 +75,7 @@ func New(path string, includeEnv bool) (*Config, error) {
 	if err := k.Unmarshal("", &conf); err != nil {
 		return nil, fmt.Errorf("error unmarshalling config: %w", err)
 	}
+	conf.applyDefaults()
 	return &conf, nil
 }
 
@@ -90,11 +95,26 @@ func NewFromMap(data map[string]interface{}) (*Config, error) {
 }
 
 func (c *Config) Validate() error {
-	if c.IMDb.Email == nil {
-		return fmt.Errorf("config field 'IMDB_EMAIL' is required")
+	if c.IMDb.Auth == nil {
+		return fmt.Errorf("config field 'IMDB_AUTH' is required")
 	}
-	if c.IMDb.Password == nil {
-		return fmt.Errorf("config field 'IMDB_PASSWORD' is required")
+	switch *c.IMDb.Auth {
+	case IMDbAuthMethodCredentials:
+		if c.IMDb.Email == nil {
+			return fmt.Errorf("config field 'IMDB_EMAIL' is required")
+		}
+		if c.IMDb.Password == nil {
+			return fmt.Errorf("config field 'IMDB_PASSWORD' is required")
+		}
+	case IMDbAuthMethodCookies:
+		if c.IMDb.CookieAtMain == nil {
+			return fmt.Errorf("config field 'IMDB_COOKIEATMAIN' is required")
+		}
+		if c.IMDb.CookieUbidMain == nil {
+			return fmt.Errorf("config field 'IMDB_COOKIEUBIDMAIN' is required")
+		}
+	default:
+		return fmt.Errorf("config field 'IMDB_AUTH' must be one of: %s", strings.Join(validIMDbAuthMethods(), ", "))
 	}
 	if c.Trakt.Email == nil {
 		return fmt.Errorf("config field 'TRAKT_EMAIL' is required")
@@ -108,15 +128,13 @@ func (c *Config) Validate() error {
 	if c.Trakt.ClientSecret == nil {
 		return fmt.Errorf("config field 'TRAKT_CLIENTSECRET' is required")
 	}
+	if c.Sync.Mode == nil {
+		return fmt.Errorf("config field 'SYNC_MODE' is required")
+	}
 	if !slices.Contains(validSyncModes(), *c.Sync.Mode) {
 		return fmt.Errorf("config field 'SYNC_MODE' must be one of: %s", strings.Join(validSyncModes(), ", "))
 	}
-	c.stripSpace()
-	if c.IMDb.Lists == nil {
-		var emptySlice []string
-		c.IMDb.Lists = &emptySlice
-	}
-	return nil
+	return c.checkDummies()
 }
 
 func (c *Config) WriteFile(path string) error {
@@ -131,27 +149,53 @@ func (c *Config) Flatten() map[string]interface{} {
 	return c.koanf.All()
 }
 
-func (c *Config) stripSpace() {
-	imdbEmail := stripSpace(*c.IMDb.Email)
-	traktEmail := stripSpace(*c.Trakt.Email)
-	traktClientID := stripSpace(*c.Trakt.ClientID)
-	traktClientSecret := stripSpace(*c.Trakt.ClientSecret)
-	syncMode := stripSpace(*c.Sync.Mode)
-	c.IMDb.Email = &imdbEmail
-	c.Trakt.Email = &traktEmail
-	c.Trakt.ClientID = &traktClientID
-	c.Trakt.ClientSecret = &traktClientSecret
-	c.Sync.Mode = &syncMode
-}
-
-func stripSpace(s string) string {
-	var sb strings.Builder
-	for _, r := range s {
-		if !unicode.IsSpace(r) {
-			sb.WriteRune(r)
+func (c *Config) checkDummies() error {
+	for k, v := range c.koanf.All() {
+		if value, ok := v.(string); ok {
+			if match := slices.Contains(dummyValues(), value); match {
+				return fmt.Errorf("config field '%s' contains dummy value '%s'", k, value)
+			}
+			continue
+		}
+		if value, ok := v.([]interface{}); ok {
+			for _, sliceElement := range value {
+				if str, isStr := sliceElement.(string); isStr {
+					if match := slices.Contains(dummyValues(), str); match {
+						return fmt.Errorf("config field '%s' contains dummy value '%s'", k, str)
+					}
+				}
+			}
 		}
 	}
-	return sb.String()
+	return nil
+}
+
+func (c *Config) applyDefaults() {
+	if c.IMDb.Auth == nil {
+		c.IMDb.Auth = pointer(IMDbAuthMethodCredentials)
+	}
+	if c.IMDb.Lists == nil {
+		c.IMDb.Lists = pointer(make([]string, 0))
+	}
+	if c.IMDb.Trace == nil {
+		c.IMDb.Trace = pointer(false)
+	}
+	if c.IMDb.Headless == nil {
+		c.IMDb.Headless = pointer(true)
+	}
+	if c.Sync.Mode == nil {
+		c.Sync.Mode = pointer(SyncModeFull)
+	}
+	if c.Sync.History == nil {
+		c.Sync.History = pointer(true)
+	}
+	if c.Sync.Timeout == nil {
+		c.Sync.Timeout = pointer(SyncTimeoutDefault)
+	}
+}
+
+func pointer[T any](v T) *T {
+	return &v
 }
 
 func validSyncModes() []string {
@@ -162,20 +206,32 @@ func validSyncModes() []string {
 	}
 }
 
+func validIMDbAuthMethods() []string {
+	return []string{
+		IMDbAuthMethodCredentials,
+		IMDbAuthMethodCookies,
+	}
+}
+
+func dummyValues() []string {
+	return []string{
+		"user@domain.com",
+		"password123",
+		"zAta|RHiA67JIrBDPaswIym3GyrTlEuQH-u9yrKP3BUNCHgVyE4oNtUzBYVKlhjjzBiM_Z-GSVnH9rKW3Hf7LdbejovoF6SI4ZmgJcTIUXoA4NVcH1Qahwm0KYCyz95o1gsgby-uQwdU6CoS6MFTnjMkLe1puNiv4uFkvo8mOQulJJeutzYedxiUd0ns9w1X_WeVXPTZWjwisPZMw3EOR6-q9xR4kCEWRW7CmWxU1AEDQbT8ns_AJJD34w1nIQUkuLgBQrvJI_pY",
+		"301-0710501-5367639",
+		"ls000000000",
+		"ls111111111",
+		"828832482dea6fffa4453f849fe873de8be54791b9acc01f6923098d0a62972d",
+		"bdf9bab88c17f3710a6394607e96cd3a21dee6e5ea0e0236e9ed06e425ed8b6f",
+	}
+}
+
 func environmentVariableModifier(key string, value string) (string, any) {
 	key = strings.TrimPrefix(key, prefix)
 	if value == "" {
 		switch key {
-		case "IMDB_HEADLESS":
-			return key, true
-		case "IMDB_TRACE":
-			return key, false
-		case "SYNC_MODE":
-			return key, SyncModeFull
-		case "SYNC_SKIPHISTORY":
-			return key, true
-		case "SYNC_TIMEOUT":
-			return key, SyncTimeoutDefault
+		case "IMDB_LISTS":
+			return key, make([]string, 0)
 		}
 		return key, nil
 	}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -240,7 +240,7 @@ func (s *Syncer) syncRatings() error {
 }
 
 func (s *Syncer) syncHistory() error {
-	if *s.conf.SkipHistory {
+	if !*s.conf.History {
 		s.logger.Info("skipping history sync")
 		return nil
 	}


### PR DESCRIPTION
The authentication method for IMDb can be specified via the `IMDB_AUTH` configuration field.
The value must be one of the following and the dependent fields must also be set:
- credentials - depends on `IMDB_EMAIL` & `IMDB_PASSWORD`
- cookies - depends on `IMDB_COOKIEATMAIN` & `IMDB_COOKIEUBIDMAIN`

Relates to #48

I will provide one additional IMDb authentication method over the next few days.
Its name will be `none` and it will allow users to sync public IMDb lists to Trakt.